### PR TITLE
usage of printrss "main url" new field in cpskin.core

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.13.1 (unreleased)
 -------------------
 
+- Add usage of new url field with collective.printrss in cpskincore_macros template.
+  [boulch]
+
 - Add CSS / JS for minisite dropdown menu : WEBOTT-9
   [laulaz]
 

--- a/cpskin/core/browser/templates/cpskincore_macros.pt
+++ b/cpskin/core/browser/templates/cpskincore_macros.pt
@@ -334,9 +334,15 @@
       <div class=""
            tal:condition="python: content.portal_type == 'rss_feed'"
 	   tal:attributes="class string:bloc-${repeat/content/number} bloc-collection-rss ${content/id} ${bloc_class}">
-           <a tal:attributes="href content/url" target="_blank" class="rss-title"><h2 tal:content="content/title" /></a>
+           <a tal:attributes="href python:content.url_main or ('/'.join(content.url.split('/', 3)[:3])
+	       if content.url.startswith('http') 
+	       else '/'.join('http://{}'.format(content.url).split('/', 3)[:3]))"
+	       target="_blank" class="rss-title"><h2 tal:content="content/title" /></a>
            <span tal:replace="structure content/@@rss_feed_macro" />
-           <a tal:attributes="href content/url" target="_blank" class="view-all" tal:content="content/title" />
+           <a tal:attributes="href python:content.url_main or ('/'.join(content.url.split('/', 3)[:3])
+	       if content.url.startswith('http') 
+	       else '/'.join('http://{}'.format(content.url).split('/', 3)[:3]))"
+	       target="_blank" class="view-all" tal:content="content/title" />
       </div>
     </tal:def>
   </metal:homepage>


### PR DESCRIPTION
If user click on feed title link in folderview , user will be redirect to new "main url" print_rss field instead of ".rss" link.