### PR TITLE
Define a default file size limit in collective.quickupload product.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.13.18 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Define a default file size limit in collective.quickupload product. Make upgradestep (set_quickupload_properties)
+  [boulch]
 
 
 0.13.17 (2019-08-05)

--- a/cpskin/core/profiles.zcml
+++ b/cpskin/core/profiles.zcml
@@ -42,7 +42,15 @@
         />
 
     <!-- Upgrade steps -->
- 
+    <genericsetup:upgradeStep
+        title="CPSKIN Core: upgrade to v60: Set some properties (ex: file size) in collective.quickupload"
+        description="Set some properties (ex: file size) in collective.quickupload"
+        handler=".upgradehandlers.set_quickupload_properties"
+        source="59"
+        destination="60"
+        profile="cpskin.core:default"
+        />
+
     <genericsetup:upgradeStep
         title="CPSKIN Core: upgrade to v59: Add registry for new document view (folderish)"
         description="Add new view on folderish document (but children items aren't print below document)"

--- a/cpskin/core/setuphandlers.py
+++ b/cpskin/core/setuphandlers.py
@@ -64,7 +64,7 @@ def installCore(context):
                                     container=portal)
         footer.setTitle(footer_name)
 
-    configCollectiveQucikupload(portal)
+    configCollectiveQucikupload()
 
     addLoadPageMenuToRegistry()
     addAutoPlaySliderToRegistry()
@@ -257,7 +257,7 @@ def addImageFromFile(portal, fileName):
         image.reindexObject()
 
 
-def configCollectiveQucikupload(portal):
+def configCollectiveQucikupload():
     ptool = api.portal.get_tool('portal_properties')
     qu_props = ptool.get('quickupload_properties')
     if not qu_props.hasProperty('show_upload_action'):
@@ -268,6 +268,10 @@ def configCollectiveQucikupload(portal):
         qu_props._setProperty('sim_upload_limit', 1, 'int')
     else:
         qu_props.sim_upload_limit = 1
+    if not qu_props.hasProperty('size_limit'):
+        qu_props._setProperty('size_limit', 30000, 'int')
+    else:
+        qu_props.sim_upload_limit = 30000
 
 
 def addLoadPageMenuToRegistry():

--- a/cpskin/core/upgradehandlers.py
+++ b/cpskin/core/upgradehandlers.py
@@ -24,6 +24,7 @@ from cpskin.core.setuphandlers import addTopMenuContentsToRegistry
 from cpskin.core.setuphandlers import addTopMenuLeadImageToRegistry
 from cpskin.core.setuphandlers import addPersonContactCoreFallbackToRegistry
 from cpskin.core.setuphandlers import add_other_xhtml_valid_tags
+from cpskin.core.setuphandlers import configCollectiveQucikupload
 from cpskin.core.utils import add_behavior
 from cpskin.core.utils import remove_behavior
 from cpskin.locales import CPSkinMessageFactory as _
@@ -507,3 +508,6 @@ def upgrade_footer_minisite(context):
 def upgrade_css_js_registry(context):
     context.runImportStepFromProfile("profile-cpskin.core:default", "cssregistry")
     context.runImportStepFromProfile("profile-cpskin.core:default", "jsregistry")
+
+def set_quickupload_properties(context):
+    configCollectiveQucikupload()


### PR DESCRIPTION
Define a default file size limit in collective.quickupload product. Make upgradestep (set_quickupload_properties)