### PR TITLE
Add setting to choose wich taxonomies should be indexed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.13.24 (unreleased)
 --------------------
 
+- Add setting to choose wich taxonomies should be indexed : MWEBOLNA-3
+  [laulaz]
+
 - Translations harmonization
   [laulaz]
 

--- a/cpskin/core/browser/controlpanel.py
+++ b/cpskin/core/browser/controlpanel.py
@@ -248,6 +248,14 @@ class CPSkinControlPanelAdapter(SchemaAdapterBase):
 
     footer_class = property(getFooterClass, setFooterClass)
 
+    def getIndexedTaxonomies(self):
+        return self.settings.indexed_taxonomies
+
+    def setIndexedTaxonomies(self, value):
+        self.settings.indexed_taxonomies = value
+
+    indexed_taxonomies = property(getIndexedTaxonomies, setIndexedTaxonomies)
+
 
 class CPSkinControlPanel(ControlPanelForm):
 

--- a/cpskin/core/indexer.py
+++ b/cpskin/core/indexer.py
@@ -15,6 +15,7 @@ from plone.indexer.interfaces import IIndexer
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.ZCatalog.interfaces import IZCatalog
+from plone import api
 from zope.component import adapts
 from zope.component import getUtility
 from zope.component.interfaces import ComponentLookupError
@@ -93,7 +94,9 @@ class OrganizationExtender(object):
             )
         text = u" ".join(text_items)
 
-        taxonomy_ids = ["types_activites"]
+        taxonomy_ids = api.portal.get_registry_record(
+            'cpskin.core.interfaces.ICPSkinSettings.indexed_taxonomies')  # noqa
+        taxonomy_ids = taxonomy_ids.split("\n")
         taxo_items = []
         lang = self.context.language
         for taxonomy_id in taxonomy_ids:

--- a/cpskin/core/interfaces.py
+++ b/cpskin/core/interfaces.py
@@ -231,6 +231,13 @@ class ICPSkinSettings(Interface):
         default=None
     )
 
+    indexed_taxonomies = schema.Text(
+        title=_(u'Taxonomies to index'),
+        description=_(u'List of taxonomy IDs (one per line) that should be indexed.'),
+        required=False,
+        default=u'types_activites\n'
+    )
+
 
 class IVideoCollection(Interface):
     """

--- a/cpskin/core/profiles.zcml
+++ b/cpskin/core/profiles.zcml
@@ -43,6 +43,14 @@
 
     <!-- Upgrade steps -->
     <genericsetup:upgradeStep
+      title="CPSKIN Core: upgrade to v63: Add indexed taxonomies setting"
+      source="62"
+      destination="63"
+      handler=".upgradehandlers.upgrade_indexed_taxonomies"
+      profile="cpskin.core:default"
+    />
+
+    <genericsetup:upgradeStep
       title="CPSKIN Core: upgrade to v62: Add searchable behaviors on organizations"
       source="61"
       destination="62"

--- a/cpskin/core/setuphandlers.py
+++ b/cpskin/core/setuphandlers.py
@@ -641,6 +641,23 @@ def addContentClassesToRegistry():
     records['cpskin.core.interfaces.ICPSkinSettings.footer_class'] = record
 
 
+def addIndexedTaxonomiesToRegistry():
+    registry = getUtility(IRegistry)
+    records = registry.records
+
+    if 'cpskin.core.interfaces.ICPSkinSettings.indexed_taxonomies' in records:  # noqa
+        return
+
+    logger.info(
+        'Adding cpskin.core.interfaces.ICPSkinSettings.indexed_taxonomies to registry')  # noqa
+    record = Record(field.Text(title=_(u'Taxonomies to index'),
+                               description=_(u'List of taxonomy IDs (one per line) that should be indexed.'),
+                               required=False,
+                               default=u'types_activites\n'),
+                    value=u'types_activites\n')
+    records['cpskin.core.interfaces.ICPSkinSettings.indexed_taxonomies'] = record
+
+
 def set_googleapi_key():
     record_name = 'collective.geo.settings.interfaces.IGeoSettings.googleapi'
     default_value = 'AIzaSyDmbfEFrVcZ_x7Snn4Kv_WkqCmiZXn01rY'

--- a/cpskin/core/upgradehandlers.py
+++ b/cpskin/core/upgradehandlers.py
@@ -15,6 +15,7 @@ from cpskin.core.setuphandlers import addCollapseMinisiteMenuToRegistry
 from cpskin.core.setuphandlers import addFooterSitemapToRegistry
 from cpskin.core.setuphandlers import addContentClassesToRegistry
 from cpskin.core.setuphandlers import addDescriptionOnThemesOptionToRegistry
+from cpskin.core.setuphandlers import addIndexedTaxonomiesToRegistry
 from cpskin.core.setuphandlers import addLoadPageMenuToRegistry
 from cpskin.core.setuphandlers import addMediaViewletOptionsToRegistry
 from cpskin.core.setuphandlers import addPortletsInRightActionsToRegistry
@@ -344,6 +345,10 @@ def upgrade_city_name(context):
 
 def upgrade_slider_type(context):
     addSliderTypeToRegistry()
+
+
+def upgrade_indexed_taxonomies(context):
+    addIndexedTaxonomiesToRegistry()
 
 
 def upgrade_search_position(context):


### PR DESCRIPTION
This refs MWEBOLNA-3

Test should be fixed before merging ...
```
Traceback (most recent call last):
  File "/Users/laurent/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 366, in run_layer
    setup_layer(options, layer, setup_layers)
  File "/Users/laurent/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 628, in setup_layer
    setup_layer(options, base, setup_layers)
  File "/Users/laurent/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 633, in setup_layer
    layer.setUp()
  File "/Users/laurent/.buildout/eggs/plone.app.testing-4.2.6-py2.7.egg/plone/app/testing/helpers.py", line 343, in setUp
    self.setUpPloneSite(portal)
  File "/Users/laurent/instances/cpskin.core/cpskin/core/testing.py", line 37, in setUpPloneSite
    applyProfile(portal, 'cpskin.core:testing')
  File "/Users/laurent/.buildout/eggs/plone.app.testing-4.2.6-py2.7.egg/plone/app/testing/helpers.py", line 113, in applyProfile
    setupTool.runAllImportStepsFromProfile(profileId)
  File "/Users/laurent/.buildout/eggs/Products.GenericSetup-1.8.9-py2.7.egg/Products/GenericSetup/tool.py", line 388, in runAllImportStepsFromProfile
    dependency_strategy=dependency_strategy)
   - __traceback_info__: profile-cpskin.core:testing
  File "/Users/laurent/.buildout/eggs/Products.GenericSetup-1.8.9-py2.7.egg/Products/GenericSetup/tool.py", line 1433, in _runImportStepsFromContext
    message = self._doRunImportStep(step, context)
  File "/Users/laurent/.buildout/eggs/Products.GenericSetup-1.8.9-py2.7.egg/Products/GenericSetup/tool.py", line 1245, in _doRunImportStep
    return handler(context)
   - __traceback_info__: plone.app.registry
  File "/Users/laurent/.buildout/eggs/plone.app.registry-1.2.5-py2.7.egg/plone/app/registry/exportimport/handler.py", line 73, in importRegistry
    importer.importDocument(body)
  File "/Users/laurent/.buildout/eggs/plone.app.registry-1.2.5-py2.7.egg/plone/app/registry/exportimport/handler.py", line 121, in importDocument
    self.importRecords(node)
  File "/Users/laurent/.buildout/eggs/plone.app.registry-1.2.5-py2.7.egg/plone/app/registry/exportimport/handler.py", line 347, in importRecords
    self.importRecord(field)
  File "/Users/laurent/.buildout/eggs/plone.app.registry-1.2.5-py2.7.egg/plone/app/registry/exportimport/handler.py", line 239, in importRecord
    <field /> element or reference an interface and field name." % name)
ValueError: Cannot find a field for the record plone.resources/leaflet.css. Add a                 <field /> element or reference an interface and field name.
```